### PR TITLE
feat(pipeline): support asterisk opt file

### DIFF
--- a/domain/pipeline/pipeline_new_job_install.go
+++ b/domain/pipeline/pipeline_new_job_install.go
@@ -161,6 +161,9 @@ func (p pipeline) newJobInstall(groupId string, tag *string) (job *jobInstance, 
 					// Copy opt files
 					for _, src := range service.Opt {
 						dest := pathOptDir + src
+						if src == "*" {
+							dest = pathOptDir
+						}
 						cpOption := unix.CpOption{Recursive: true, Force: true}
 						if strings.Contains(strings.TrimSuffix(src, "/"), "/") {
 							dest = pathOptDir


### PR DESCRIPTION
# Reproduce

```toml
[[systemd_services]]
name = "sample"
opt_files = ["*"]
```

```_
ERRO[0000] FAILED - Execute command
ERRO[0000] command = /usr/bin/bash -c cd /usr/local/systemd-cd/src/sample ; cp -R -f * /usr/local/systemd-cd/opt/ictsc-rikka/*
ERRO[0000] cp: target '/usr/local/systemd-cd/opt/sample/*' is not a directory
ERRO[0000] exit status1
```